### PR TITLE
fix: correct logical operators in navigation script

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -134,7 +134,7 @@ $(function() {
         if ((width >= custom_width)) {
 
             /* if desktop */
-            if (!menu_item.hasClass('active') & (width > 1023) & $('#home-card').length) {
+            if (!menu_item.hasClass('active') && (width > 1023) && $('#home-card').length) {
 
                 /* close card items */
                 menu_items.removeClass('active');
@@ -157,7 +157,7 @@ $(function() {
             }
         }
         /* if tablet */
-        if ((width < custom_width) & (width > 560) & $('#home-card').length) {
+        if ((width < custom_width) && (width > 560) && $('#home-card').length) {
 
             /* scroll to section */
             $('body,html').animate({
@@ -165,7 +165,7 @@ $(function() {
             }, 800);
         }
         /* if mobile */
-        if ((width < 561) & $('#home-card').length) {
+        if ((width < 561) && $('#home-card').length) {
 
             /* scroll to section */
             $('body,html').animate({
@@ -270,7 +270,7 @@ $(function() {
     	Smoothscroll
     */
 
-    if ((width < 1024) & $('#home-card').length) {
+    if ((width < 1024) && $('#home-card').length) {
         $(window).on('scroll', function() {
             var scrollPos = $(window).scrollTop();
             $('.top-menu ul li a').each(function() {


### PR DESCRIPTION
## Summary
- replace bitwise `&` with logical `&&` in navigation and scrolling checks

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893930260d0832bbfcd2fe330c8fdf7