### PR TITLE
Improve menu layout and lazy-load iframe

### DIFF
--- a/css/new-skin/new-skin.css
+++ b/css/new-skin/new-skin.css
@@ -667,10 +667,11 @@ input[type="file"] {
     }
     .header .top-menu ul {
         display: flex;
-        overflow: auto;
+        flex-wrap: wrap;
+        overflow: visible;
     }
     .header .top-menu ul li {
-        min-width: 20%;
+        flex: 0 0 20%;
     }
     .header .top-menu ul li a {
         padding: 13px 7px;

--- a/index.html
+++ b/index.html
@@ -660,7 +660,7 @@
 
                         <!-- title -->
                         <div class="title">Testimonials</div>
-                        <iframe src='https://widgets.sociablekit.com/linkedin-recommendations/iframe/25501312' frameborder='0' width='100%' height='1000'></iframe>
+                        <iframe loading="lazy" src='https://widgets.sociablekit.com/linkedin-recommendations/iframe/25501312' frameborder='0' width='100%' height='1000'></iframe>
                         <!-- content -->
                         <div class="row testimonials-items">
 


### PR DESCRIPTION
## Summary
- Wrap mobile navigation links onto two lines for horizontal menu display
- Lazy-load embedded testimonials iframe to speed up page load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894e16e51a8832b956af9fdbdee2948