### PR TITLE
Make mobile menu horizontal on mobile

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -290,11 +290,13 @@
     }
     .header .top-menu ul {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
+        justify-content: space-around;
         width: 100%;
     }
     .header .top-menu ul li {
-        width: 100%;
+        flex: 1 1 auto;
+        width: auto;
     }
     .header .top-menu ul li a {
         padding: 10px 0;

--- a/css/new-skin/new-skin.css
+++ b/css/new-skin/new-skin.css
@@ -581,16 +581,17 @@ input[type="file"] {
     .header .top-menu {
         margin: 0 auto;
         max-width: 100%;
-        display: block;
+        display: flex;
+        justify-content: space-around;
         box-shadow: none;
     }
     .header .top-menu ul {
-        display: block;
+        display: flex;
         width: 100%;
     }
     .header .top-menu ul li {
-        display: block;
-        width: 100%;
+        flex: 1 1 auto;
+        width: auto;
     }
     .header .top-menu ul li:first-child a {
         border-radius: 4px 0 0 4px;

--- a/pro/css/layout.css
+++ b/pro/css/layout.css
@@ -270,11 +270,12 @@
         margin: 0 auto;
         max-width: 540px;
         display: flex;
+        justify-content: space-around;
         box-shadow: 0 0 25px rgba(0, 0, 0, .05)
     }
     .header .top-menu ul li {
-        display: block;
-        width: 100%
+        flex: 1 1 auto;
+        width: auto
     }
     .header .top-menu ul li:first-child a {
         border-radius: 4px 0 0 4px;

--- a/pro/css/new-skin/new-skin.css
+++ b/pro/css/new-skin/new-skin.css
@@ -581,16 +581,17 @@ input[type="file"] {
     .header .top-menu {
         margin: 0 auto;
         max-width: 100%;
-        display: block;
+        display: flex;
+        justify-content: space-around;
         box-shadow: none;
     }
     .header .top-menu ul {
-        display: block;
+        display: flex;
         width: 100%;
     }
     .header .top-menu ul li {
-        display: block;
-        width: 100%;
+        flex: 1 1 auto;
+        width: auto;
     }
     .header .top-menu ul li:first-child a {
         border-radius: 4px 0 0 4px;


### PR DESCRIPTION
## Summary
- Arrange mobile navigation items horizontally using flex layout
- Align "pro" styles with horizontal mobile menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f092ec0c832bb83cd53488740783