### PR TITLE
Arrange menu into two vertical columns

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -2999,27 +2999,25 @@ p.no-comments {
     display: none !important
 }
 
-/* allow menu to wrap into two lines */
+/* display menu in two vertical columns */
 .header .top-menu ul {
-    display: flex;
-    flex-wrap: wrap;
-}
-@media (min-width:1024px) {
-    .header .top-menu ul li {
-        width: 50%;
-    }
-}
-@media (max-width:1023px) {
-    .header .top-menu ul li {
-        width: 20%;
-    }
+    column-count: 2;
+    column-gap: 20px;
+    display: block;
 }
 
+.header .top-menu ul li {
+    break-inside: avoid;
+}
+
+/* collapse menu into a single column on small screens */
 @media (max-width: 600px) {
+    .header .top-menu ul {
+        column-count: 1;
+    }
     .header .top-menu ul li a .link {
         display: none;
     }
-
     .header .top-menu ul li a {
         padding: 10px 0;
     }

--- a/css/new-skin/new-skin.css
+++ b/css/new-skin/new-skin.css
@@ -2804,3 +2804,21 @@ a.next.page-numbers:hover {
         padding-top: 118px;
     }
 }
+
+/* display top menu in two vertical columns */
+.header .top-menu ul {
+    column-count: 2;
+    column-gap: 20px;
+    display: block;
+}
+
+.header .top-menu ul li {
+    break-inside: avoid;
+}
+
+/* collapse menu to a single column on small screens */
+@media (max-width: 560px) {
+    .header .top-menu ul {
+        column-count: 1;
+    }
+}

--- a/pro/css/layout.css
+++ b/pro/css/layout.css
@@ -2998,3 +2998,27 @@ p.no-comments {
 .typed-cursor {
     display: none !important
 }
+
+/* display menu in two vertical columns */
+.header .top-menu ul {
+    column-count: 2;
+    column-gap: 20px;
+    display: block;
+}
+
+.header .top-menu ul li {
+    break-inside: avoid;
+}
+
+/* collapse menu into a single column on small screens */
+@media (max-width: 600px) {
+    .header .top-menu ul {
+        column-count: 1;
+    }
+    .header .top-menu ul li a .link {
+        display: none;
+    }
+    .header .top-menu ul li a {
+        padding: 10px 0;
+    }
+}

--- a/pro/css/new-skin/new-skin.css
+++ b/pro/css/new-skin/new-skin.css
@@ -2803,3 +2803,21 @@ a.next.page-numbers:hover {
         padding-top: 118px;
     }
 }
+
+/* display top menu in two vertical columns */
+.header .top-menu ul {
+    column-count: 2;
+    column-gap: 20px;
+    display: block;
+}
+
+.header .top-menu ul li {
+    break-inside: avoid;
+}
+
+/* collapse menu to a single column on small screens */
+@media (max-width: 560px) {
+    .header .top-menu ul {
+        column-count: 1;
+    }
+}


### PR DESCRIPTION
## Summary
- Display header menu using two vertical columns with CSS `column-count`
- Collapse menu into a single column on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f1e008a4832b925545257baa8b08