### PR TITLE
Improve responsive navigation menu

### DIFF
--- a/awards.html
+++ b/awards.html
@@ -64,7 +64,7 @@
                 </div>
 
                 <!-- menu btn -->
-                <a href="#" class="menu-btn"><span></span></a>
+                <button class="nav-toggle" id="mobile-menu-toggle" aria-label="Toggle navigation"><span></span></button>
 
                 <!-- menu -->
                 <div class="top-menu">

--- a/certifications.html
+++ b/certifications.html
@@ -64,7 +64,7 @@
                 </div>
 
                 <!-- menu btn -->
-                <a href="#" class="menu-btn"><span></span></a>
+                <button class="nav-toggle" id="mobile-menu-toggle" aria-label="Toggle navigation"><span></span></button>
 
                 <!-- menu -->
                 <div class="top-menu">

--- a/css/new-skin/new-skin.css
+++ b/css/new-skin/new-skin.css
@@ -2822,3 +2822,87 @@ a.next.page-numbers:hover {
         column-count: 1;
     }
 }
+
+/* Responsive navigation fixes */
+.header {
+    margin: 0;
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    max-width: 100%;
+    height: 60px;
+    padding: 0 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #fff;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.header .profile {
+    display: flex;
+    align-items: center;
+}
+
+.header .top-menu {
+    margin: 0;
+    width: auto;
+}
+
+.header .top-menu ul {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+}
+
+.header .top-menu ul li {
+    width: auto;
+    flex: 0 0 auto;
+}
+
+.header .top-menu ul li a {
+    padding: 10px 15px;
+}
+
+.header .top-menu ul li a:before {
+    display: none;
+}
+
+.header .nav-toggle {
+    display: none;
+}
+
+@media (max-width: 768px) {
+    .header {
+        flex-wrap: wrap;
+        height: auto;
+    }
+
+    .header .nav-toggle {
+        display: block;
+    }
+
+    .header .top-menu {
+        display: none;
+        width: 100%;
+        box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
+    }
+
+    .header .top-menu.open {
+        display: block;
+    }
+
+    .header .top-menu ul {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .header .top-menu ul li {
+        width: 100%;
+    }
+
+    .header .top-menu ul li a {
+        width: 100%;
+    }
+}

--- a/leadership.html
+++ b/leadership.html
@@ -64,7 +64,7 @@
                 </div>
 
                 <!-- menu btn -->
-                <a href="#" class="menu-btn"><span></span></a>
+                <button class="nav-toggle" id="mobile-menu-toggle" aria-label="Toggle navigation"><span></span></button>
 
                 <!-- menu -->
                 <div class="top-menu">

--- a/pro/css/new-skin/new-skin.css
+++ b/pro/css/new-skin/new-skin.css
@@ -2821,3 +2821,87 @@ a.next.page-numbers:hover {
         column-count: 1;
     }
 }
+
+/* Responsive navigation fixes */
+.header {
+    margin: 0;
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    max-width: 100%;
+    height: 60px;
+    padding: 0 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #fff;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.header .profile {
+    display: flex;
+    align-items: center;
+}
+
+.header .top-menu {
+    margin: 0;
+    width: auto;
+}
+
+.header .top-menu ul {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+}
+
+.header .top-menu ul li {
+    width: auto;
+    flex: 0 0 auto;
+}
+
+.header .top-menu ul li a {
+    padding: 10px 15px;
+}
+
+.header .top-menu ul li a:before {
+    display: none;
+}
+
+.header .nav-toggle {
+    display: none;
+}
+
+@media (max-width: 768px) {
+    .header {
+        flex-wrap: wrap;
+        height: auto;
+    }
+
+    .header .nav-toggle {
+        display: block;
+    }
+
+    .header .top-menu {
+        display: none;
+        width: 100%;
+        box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
+    }
+
+    .header .top-menu.open {
+        display: block;
+    }
+
+    .header .top-menu ul {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .header .top-menu ul li {
+        width: 100%;
+    }
+
+    .header .top-menu ul li a {
+        width: 100%;
+    }
+}

--- a/pro/index.html
+++ b/pro/index.html
@@ -142,7 +142,7 @@
                 </div>
 
                 <!-- menu btn -->
-                <a href="#" class="menu-btn"><span></span></a>
+                <button class="nav-toggle" id="mobile-menu-toggle" aria-label="Toggle navigation"><span></span></button>
 
                 <!-- menu -->
                 <div class="top-menu">

--- a/pro/js/scripts.js
+++ b/pro/js/scripts.js
@@ -616,6 +616,12 @@ $(function() {
         }
     });
 
+    /* Mobile menu toggle */
+    $('#mobile-menu-toggle').on('click', function(e) {
+        e.preventDefault();
+        $('.top-menu').toggleClass('open');
+    });
+
 });
 
 

--- a/projects.html
+++ b/projects.html
@@ -64,7 +64,7 @@
                 </div>
 
                 <!-- menu btn -->
-                <a href="#" class="menu-btn"><span></span></a>
+                <button class="nav-toggle" id="mobile-menu-toggle" aria-label="Toggle navigation"><span></span></button>
 
                 <!-- menu -->
                 <div class="top-menu">

--- a/publications.html
+++ b/publications.html
@@ -64,7 +64,7 @@
                 </div>
 
                 <!-- menu btn -->
-                <a href="#" class="menu-btn"><span></span></a>
+                <button class="nav-toggle" id="mobile-menu-toggle" aria-label="Toggle navigation"><span></span></button>
 
                 <!-- menu -->
                 <div class="top-menu">


### PR DESCRIPTION
## Summary
- Replace broken sidebar trigger with a standard mobile nav toggle across all pages
- Add responsive header and menu styles for desktop and mobile layouts
- Enable JavaScript toggle in the `pro` demo

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68977eec08fc832b88f3bd50c86dab41