### PR TITLE
Fix responsive menu styling

### DIFF
--- a/awards.html
+++ b/awards.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="css/gradient.css" />
     <link rel="stylesheet" href="css/new-skin/new-skin.css" />
     <link rel="stylesheet" href="css/demos/demo-1-colors.css" />
+    <link rel="stylesheet" href="css/menu.css" />
 </head>
 <body>
     <div class="page new-skin">

--- a/certifications.html
+++ b/certifications.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="css/gradient.css" />
     <link rel="stylesheet" href="css/new-skin/new-skin.css" />
     <link rel="stylesheet" href="css/demos/demo-1-colors.css" />
+    <link rel="stylesheet" href="css/menu.css" />
 </head>
 <body>
     <div class="page new-skin">

--- a/css/menu.css
+++ b/css/menu.css
@@ -1,0 +1,90 @@
+/* Responsive menu overrides */
+.header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 60px;
+  padding: 0 20px;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  z-index: 1000;
+}
+
+.header .profile {
+  display: flex;
+  flex-direction: column;
+}
+
+.header .top-menu {
+  display: flex;
+}
+
+.header .top-menu ul {
+  display: flex;
+  gap: 10px;
+}
+
+.header .top-menu ul li {
+  list-style: none;
+}
+
+.header .top-menu ul li a {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 15px;
+}
+
+.header .nav-toggle {
+  background: none;
+  border: 0;
+  width: 40px;
+  height: 40px;
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .header .nav-toggle {
+    display: block;
+  }
+  .header .top-menu {
+    position: absolute;
+    top: 60px;
+    left: 0;
+    width: 100%;
+    background: #fff;
+    flex-direction: column;
+    display: none;
+    box-shadow: 0 5px 10px rgba(0,0,0,0.05);
+  }
+  .header .top-menu.open {
+    display: flex;
+  }
+  .header .top-menu ul {
+    flex-direction: column;
+    gap: 0;
+  }
+  .header .top-menu ul li {
+    width: 100%;
+    text-align: center;
+  }
+  .header .top-menu ul li a {
+    padding: 15px;
+  }
+}
+
+/* offset page content from fixed header */
+.container {
+  padding-top: 80px;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding-top: 60px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -58,6 +58,11 @@
     <!--<link rel="stylesheet" href="css/template-colors/red.css" />-->
 
     <!--
+                Custom responsive menu styles
+        -->
+    <link rel="stylesheet" href="css/menu.css" />
+
+    <!--
 		Template Dark
 	-->
     <!--<link rel="stylesheet" href="css/template-dark/dark.css" />-->

--- a/leadership.html
+++ b/leadership.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="css/gradient.css" />
     <link rel="stylesheet" href="css/new-skin/new-skin.css" />
     <link rel="stylesheet" href="css/demos/demo-1-colors.css" />
+    <link rel="stylesheet" href="css/menu.css" />
 </head>
 <body>
     <div class="page new-skin">

--- a/pro/css/menu.css
+++ b/pro/css/menu.css
@@ -1,0 +1,90 @@
+/* Responsive menu overrides */
+.header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 60px;
+  padding: 0 20px;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  z-index: 1000;
+}
+
+.header .profile {
+  display: flex;
+  flex-direction: column;
+}
+
+.header .top-menu {
+  display: flex;
+}
+
+.header .top-menu ul {
+  display: flex;
+  gap: 10px;
+}
+
+.header .top-menu ul li {
+  list-style: none;
+}
+
+.header .top-menu ul li a {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 15px;
+}
+
+.header .nav-toggle {
+  background: none;
+  border: 0;
+  width: 40px;
+  height: 40px;
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .header .nav-toggle {
+    display: block;
+  }
+  .header .top-menu {
+    position: absolute;
+    top: 60px;
+    left: 0;
+    width: 100%;
+    background: #fff;
+    flex-direction: column;
+    display: none;
+    box-shadow: 0 5px 10px rgba(0,0,0,0.05);
+  }
+  .header .top-menu.open {
+    display: flex;
+  }
+  .header .top-menu ul {
+    flex-direction: column;
+    gap: 0;
+  }
+  .header .top-menu ul li {
+    width: 100%;
+    text-align: center;
+  }
+  .header .top-menu ul li a {
+    padding: 15px;
+  }
+}
+
+/* offset page content from fixed header */
+.container {
+  padding-top: 80px;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding-top: 60px;
+  }
+}

--- a/pro/index.html
+++ b/pro/index.html
@@ -55,6 +55,9 @@
     <!--<link rel="stylesheet" href="css/template-colors/purple.css" />-->
     <!--<link rel="stylesheet" href="css/template-colors/red.css" />-->
 
+    <!-- Custom responsive menu styles -->
+    <link rel="stylesheet" href="css/menu.css" />
+
     <!--
 		Template Dark
 	-->

--- a/projects.html
+++ b/projects.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="css/gradient.css" />
     <link rel="stylesheet" href="css/new-skin/new-skin.css" />
     <link rel="stylesheet" href="css/demos/demo-1-colors.css" />
+    <link rel="stylesheet" href="css/menu.css" />
 </head>
 <body>
     <div class="page new-skin">

--- a/publications.html
+++ b/publications.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="css/gradient.css" />
     <link rel="stylesheet" href="css/new-skin/new-skin.css" />
     <link rel="stylesheet" href="css/demos/demo-1-colors.css" />
+    <link rel="stylesheet" href="css/menu.css" />
 </head>
 <body>
     <div class="page new-skin">


### PR DESCRIPTION
## Summary
- add custom CSS for a fixed, responsive navigation bar
- include new menu stylesheet on all pages so the nav works on desktop and mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897815633a8832b84cbcfc25ff2f205