### PR TITLE
Refactor navigation for responsive sidebar

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -1,90 +1,68 @@
-/* Responsive menu overrides */
-.header {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 60px;
-  padding: 0 20px;
-  background: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  z-index: 1000;
+/* Responsive navigation and layout */
+
+/* base styles */
+.nav-grid {
+  margin: 20px 0;
 }
 
-.header .profile {
-  display: flex;
-  flex-direction: column;
-}
-
-.header .top-menu {
-  display: flex;
-}
-
-.header .top-menu ul {
-  display: flex;
-  gap: 10px;
-}
-
-.header .top-menu ul li {
+.nav-grid ul {
   list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  row-gap: 12px;
+  column-gap: 12px;
+  justify-items: center;
 }
 
-.header .top-menu ul li a {
+.nav-grid li {
+  min-width: 0;
+}
+
+.nav-grid a {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  padding: 10px 15px;
+  gap: 6px;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
-.header .nav-toggle {
-  background: none;
-  border: 0;
-  width: 40px;
-  height: 40px;
-  display: none;
+.nav-grid a:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
 }
 
-@media (max-width: 768px) {
-  .header .nav-toggle {
-    display: block;
-  }
-  .header .top-menu {
-    position: absolute;
-    top: 60px;
-    left: 0;
-    width: 100%;
-    background: #fff;
-    flex-direction: column;
-    display: none;
-    box-shadow: 0 5px 10px rgba(0,0,0,0.05);
-  }
-  .header .top-menu.open {
-    display: flex;
-  }
-  .header .top-menu ul {
-    flex-direction: column;
-    gap: 0;
-  }
-  .header .top-menu ul li {
-    width: 100%;
-    text-align: center;
-  }
-  .header .top-menu ul li a {
-    padding: 15px;
+/* tablet */
+@media (min-width: 768px) and (max-width: 1199px) {
+  .nav-grid ul {
+    grid-template-columns: repeat(4, 1fr);
+    row-gap: 16px;
+    column-gap: 20px;
   }
 }
 
-/* offset page content from fixed header */
-.container {
-  padding-top: 80px;
-  padding-left: 15px;
-  padding-right: 15px;
-}
+/* desktop */
+@media (min-width: 1200px) {
+  .layout {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    column-gap: 40px;
+    align-items: flex-start;
+  }
 
-@media (max-width: 768px) {
-  .container {
-    padding-top: 60px;
+  .nav-grid {
+    margin: 0;
+    position: sticky;
+    top: 0;
+    align-self: start;
+  }
+
+  .nav-grid ul {
+    grid-template-columns: repeat(2, 1fr);
+    row-gap: 16px;
+    column-gap: 20px;
   }
 }
+

--- a/index.html
+++ b/index.html
@@ -124,104 +124,95 @@
             </ul>
         </div>
 
-        <!--
-			Container
-		-->
-        <div class="container opened" data-animation-in="fadeInLeft" data-animation-out="fadeOutLeft">
-
-            <!--
-				Header
-			-->
-            <header class="header">
-
-                <!-- header profile -->
-                <div class="profile">
-                    <div class="title">Md. Tanvir Alam Sifat</div>
-                    <div class="subtitle subtitle-typed">
-                        <div class="typing-title">
-                            <p>Solution Architect</p>
-                            <p>Product Developer</p>
-                            <p>Project Manager</p>
-                            <p>Software Engineer</p>
-                            <p>Business Analyst</p>
-                        </div>
+        <!-- Header -->
+        <header class="header">
+            <!-- header profile -->
+            <div class="profile">
+                <div class="title">Md. Tanvir Alam Sifat</div>
+                <div class="subtitle subtitle-typed">
+                    <div class="typing-title">
+                        <p>Solution Architect</p>
+                        <p>Product Developer</p>
+                        <p>Project Manager</p>
+                        <p>Software Engineer</p>
+                        <p>Business Analyst</p>
                     </div>
                 </div>
+            </div>
+        </header>
 
-                <!-- menu btn -->
-                <button class="nav-toggle" id="mobile-menu-toggle" aria-label="Toggle navigation"><span></span></button>
+        <!-- Layout -->
+        <div class="layout">
+            <nav class="nav-grid" aria-label="Primary">
+                <ul>
+                    <li class="active">
+                        <a href="#about-card">
+                            <span class="icon ion-person"></span>
+                            <span class="link">About</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#resume-card">
+                            <span class="icon ion-android-list"></span>
+                            <span class="link">Resume</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#works-card">
+                            <span class="icon ion-paintbrush"></span>
+                            <span class="link">Works</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#projects-card">
+                            <span class="icon ion-code-working"></span>
+                            <span class="link">Projects</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#publications-card">
+                            <span class="icon ion-document-text"></span>
+                            <span class="link">Publications</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#awards-card">
+                            <span class="icon ion-ribbon-a"></span>
+                            <span class="link">Awards</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#leadership-card">
+                            <span class="icon ion-person-stalker"></span>
+                            <span class="link">Leadership</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#certifications-card">
+                            <span class="icon ion-ribbon-b"></span>
+                            <span class="link">Certifications</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#blog-card">
+                            <span class="icon ion-chatbox-working"></span>
+                            <span class="link">Blog</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#contacts-card">
+                            <span class="icon ion-at"></span>
+                            <span class="link">Contact</span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
 
-                <!-- menu -->
-                <nav class="top-menu">
-                    <ul>
-                        <li class="active">
-                            <a href="#about-card">
-								<span class="icon ion-person"></span>
-								<span class="link">About</span>
-							</a>
-                        </li>
-                        <li>
-                            <a href="#resume-card">
-								<span class="icon ion-android-list"></span>
-								<span class="link">Resume</span>
-							</a>
-                        </li>
-                        <li>
-                            <a href="#works-card">
-                                                                <span class="icon ion-paintbrush"></span>
-                                                                <span class="link">Works</span>
-                                                        </a>
-                        </li>
-                        <li>
-                            <a href="#projects-card">
-                                                                <span class="icon ion-code-working"></span>
-                                                                <span class="link">Projects</span>
-                                                        </a>
-                        </li>
-                        <li>
-                            <a href="#publications-card">
-                                                                <span class="icon ion-document-text"></span>
-                                                                <span class="link">Publications</span>
-                                                        </a>
-                        </li>
-                        <li>
-                            <a href="#awards-card">
-                                                                <span class="icon ion-ribbon-a"></span>
-                                                                <span class="link">Awards</span>
-                                                        </a>
-                        </li>
-                        <li>
-                            <a href="#leadership-card">
-                                                                <span class="icon ion-person-stalker"></span>
-                                                                <span class="link">Leadership</span>
-                                                        </a>
-                        </li>
-                        <li>
-                            <a href="#certifications-card">
-                                                                <span class="icon ion-ribbon-b"></span>
-                                                                <span class="link">Certifications</span>
-                                                        </a>
-                        </li>
-                        <li>
-                            <a href="#blog-card">
-                                                                <span class="icon ion-chatbox-working"></span>
-                                                                <span class="link">Blog</span>
-                                                        </a>
-                        </li>
-                        <li>
-                            <a href="#contacts-card">
-                                                                <span class="icon ion-at"></span>
-                                                                <span class="link">Contact</span>
-                                                        </a>
-                        </li>
-                    </ul>
-                </nav>
-
-            </header>
+            <div class="container opened" data-animation-in="fadeInLeft" data-animation-out="fadeOutLeft">
 
             <!--
-				Card - Started
-			-->
+                                Card - Started
+                        -->
             <div class="card-started" id="home-card">
 
                 <!--
@@ -1708,9 +1699,10 @@
 			<span class="close"></span>
 		</div>
 
-	</div>
+        </div>
+        </div>
 
-	<!-- bslthemes.com buttons html begin -->
+        <!-- bslthemes.com buttons html begin -->
 	<div class="bsl-popup" data-theme="ryancv" data-category="html">
 		<div class="bsl-popup__buttons"></div>
 		<div class="bsl-popup__content bsl-popup__content-related">


### PR DESCRIPTION
## Summary
- Move main navigation out of the header into its own element
- Add responsive CSS grid/flex layout for sidebar and top nav
- Implement sticky two-column sidebar on desktop and 2x4 grid above hero on smaller screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689787b02760832b8c8b9c02be62c96a